### PR TITLE
Add `@HumanRoute()` and `@ExperimentalRoute()` for LLM function excluding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrtnio/decorators",
-  "version": "1.4.12",
+  "version": "1.5.0",
   "description": "",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -8,29 +8,29 @@
   "author": "Wrtn Technologies",
   "license": "MIT",
   "devDependencies": {
-    "@nestia/core": "^3.7.1",
+    "@nestia/core": "^4.2.0",
     "@nestia/e2e": "^0.7.0",
-    "@nestia/fetcher": "^3.7.1",
-    "@nestia/sdk": "^3.7.1",
+    "@nestia/fetcher": "^4.2.0",
+    "@nestia/sdk": "^4.2.0",
     "@nestjs/common": "^10.3.10",
     "@nestjs/platform-express": "^10.3.10",
-    "@samchon/openapi": "^0.4.2",
+    "@samchon/openapi": "^2.0.3",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
     "@types/jmespath": "^0.15.2",
     "@types/node": "^20.14.11",
     "jmespath": "^0.16.0",
-    "nestia": "^6.0.1",
+    "nestia": "^6.3.1",
     "prettier": "^3.3.3",
     "rimraf": "^6.0.1",
     "ts-node": "^10.9.2",
-    "ts-patch": "^3.2.1",
-    "typescript": "^5.5.3",
-    "typia": "^6.5.1"
+    "ts-patch": "^3.3.0",
+    "typescript": "~5.7.2",
+    "typia": "^7.2.0"
   },
   "peerDependencies": {
-    "@nestia/core": ">=3.2.0",
-    "@nestia/sdk": ">=3.2.0",
-    "typia": ">=6.0.4"
+    "@nestia/core": ">=4.0.0",
+    "@nestia/sdk": ">=4.0.0",
+    "typia": ">=7.0.0"
   },
   "scripts": {
     "build": "rimraf lib && tsc",

--- a/src/Constant.ts
+++ b/src/Constant.ts
@@ -22,6 +22,7 @@ import { tags } from "typia";
  * }
  * ```
  *
+ * @deprecated `const enum` 쓰거나 `typia.tags.Constant` 로 대체해주세요
  * @author Samchon
  */
 export type Constant<

--- a/src/ExperimentalRoute.ts
+++ b/src/ExperimentalRoute.ts
@@ -1,0 +1,27 @@
+import { SwaggerCustomizer } from "@nestia/core";
+
+/**
+ * Experimental API marking.
+ *
+ * This decorator marks the API as experimental, so that LLM function calling schema composer
+ * excludes the API in the production environments. Of course, test and development environments
+ * are not affected by this decorator.
+ *
+ * In other words, if you adjust the `@ExperimentalRoute()` decorator to the API, the API never
+ * participates in the LLM function calling in the production environments. Only test and
+ * development environments can access the API through the LLM function calling.
+ *
+ * @returns Method decorator
+ * @author Samchon
+ */
+export function ExperimentalRoute(): MethodDecorator {
+  return function (
+    target: Object,
+    key: string | symbol | undefined,
+    descriptor: PropertyDescriptor,
+  ) {
+    return SwaggerCustomizer((props) => {
+      (props.route as any)["x-wrtn-experimental"] = true;
+    })(target, key!, descriptor);
+  };
+}

--- a/src/HumanRoute.ts
+++ b/src/HumanRoute.ts
@@ -1,0 +1,25 @@
+import { SwaggerCustomizer } from "@nestia/core";
+
+/**
+ * Human only API marking.
+ *
+ * This decorator marks the API as human only, so that LLM function calling schema composer
+ * excludes the API.
+ *
+ * In other words, if you adjust the `@HumanRoute()` decorator to the API, the API never
+ * participates in the LLM function calling.
+ *
+ * @returns Method decorator
+ * @author Samchon
+ */
+export function HumanRoute(): MethodDecorator {
+  return function (
+    target: Object,
+    key: string | symbol | undefined,
+    descriptor: PropertyDescriptor,
+  ) {
+    return SwaggerCustomizer((props) => {
+      (props.route as any)["x-samchon-human"] = true;
+    })(target, key!, descriptor);
+  };
+}

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,4 +1,6 @@
 export * from "./Constant";
+export * from "./ExperimentalRoute";
+export * from "./HumanRoute";
 export * from "./JMESPath";
 export * from "./Placeholder";
 export * from "./Prerequisite";

--- a/test/swagger.json
+++ b/test/swagger.json
@@ -7,7 +7,7 @@
     }
   ],
   "info": {
-    "version": "1.4.11",
+    "version": "1.5.0",
     "title": "@wrtnio/decorators",
     "description": "",
     "license": {
@@ -144,7 +144,10 @@
         },
         "responses": {
           "201": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {}
+            }
           }
         }
       }


### PR DESCRIPTION
This pull request includes updates to dependencies and the addition of new decorators to the codebase. The most important changes include version upgrades in the `package.json` file, the introduction of `ExperimentalRoute` and `HumanRoute` decorators, and updates to the `swagger.json` file.

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R33): Updated various dependencies including `@nestia/core`, `@nestia/fetcher`, `@nestia/sdk`, `@samchon/openapi`, `typescript`, and `typia`. The version of the package itself was also updated to `1.5.0`.

New decorators:

* [`src/ExperimentalRoute.ts`](diffhunk://#diff-5c27d607f820e7d87f496689d861bf9ea6f3987c2561af6d328aa258b79e9afeR1-R27): Added a new `ExperimentalRoute` decorator to mark APIs as experimental, which will exclude them from production environments' LLM function calling schema.
* [`src/HumanRoute.ts`](diffhunk://#diff-1da6ad0bea73478622fa60e11916c5dc5b3d053142d21cd7122d1e732ea5c47eR1-R25): Added a new `HumanRoute` decorator to mark APIs as human-only, excluding them from LLM function calling schema.
* [`src/module.ts`](diffhunk://#diff-030fc083b2cbf5cf008cfc0c49bb4f1b8d97ac07f93a291d068d81b4d1416f70R2-R3): Exported the new `ExperimentalRoute` and `HumanRoute` decorators.

Documentation updates:

* [`test/swagger.json`](diffhunk://#diff-ccad5c8636b63ed89e05cb28fab8884f5227258080b9155f9510afe02cd1da68L10-R10): Updated the version to `1.5.0` and added content type for responses in the Swagger documentation. [[1]](diffhunk://#diff-ccad5c8636b63ed89e05cb28fab8884f5227258080b9155f9510afe02cd1da68L10-R10) [[2]](diffhunk://#diff-ccad5c8636b63ed89e05cb28fab8884f5227258080b9155f9510afe02cd1da68L147-R150)

Deprecation notice:

* [`src/Constant.ts`](diffhunk://#diff-444b776d31a8eb9146a276b56d20b6c275126a425427d71624cbad18a7c6e809R25): Added a deprecation notice suggesting the use of `const enum` or `typia.tags.Constant`.