### PR TITLE
New decorator `@SelectBenchmark()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrtnio/decorators",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -8,13 +8,13 @@
   "author": "Wrtn Technologies",
   "license": "MIT",
   "devDependencies": {
-    "@nestia/core": "^4.2.0",
+    "@nestia/core": "^4.4.2",
     "@nestia/e2e": "^0.7.0",
-    "@nestia/fetcher": "^4.2.0",
-    "@nestia/sdk": "^4.2.0",
+    "@nestia/fetcher": "^4.4.2",
+    "@nestia/sdk": "^4.4.2",
     "@nestjs/common": "^10.3.10",
     "@nestjs/platform-express": "^10.3.10",
-    "@samchon/openapi": "^2.0.3",
+    "@samchon/openapi": "^2.2.1",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
     "@types/jmespath": "^0.15.2",
     "@types/node": "^20.14.11",
@@ -25,7 +25,7 @@
     "ts-node": "^10.9.2",
     "ts-patch": "^3.3.0",
     "typescript": "~5.7.2",
-    "typia": "^7.2.0"
+    "typia": "^7.4.1"
   },
   "peerDependencies": {
     "@nestia/core": ">=4.0.0",

--- a/src/RouteIcon.ts
+++ b/src/RouteIcon.ts
@@ -5,11 +5,11 @@ export function RouteIcon(url: string & tags.Format<"uri">): MethodDecorator {
   typia.assert(url);
   return function (
     target: Object,
-    key: string | symbol | undefined,
-    descriptor: PropertyDescriptor
+    key: string | symbol,
+    descriptor: PropertyDescriptor,
   ) {
     return SwaggerCustomizer((props) => {
       (props.route as any)["x-wrtn-icon"] = url;
-    })(target, key!, descriptor);
+    })(target, key, descriptor);
   };
 }

--- a/src/SelectBenchmark.ts
+++ b/src/SelectBenchmark.ts
@@ -1,0 +1,16 @@
+import { SwaggerCustomizer } from "@nestia/core";
+
+export function SelectBenchmark(keyword: string | string[]): MethodDecorator {
+  return function (
+    target: any,
+    key: string | symbol,
+    descriptor: PropertyDescriptor,
+  ) {
+    return SwaggerCustomizer((props) => {
+      (props.route as any)["x-wrtn-function-select-benchmarks"] ??= [];
+      (props.route as any)["x-wrtn-function-select-benchmarks"].push(
+        ...(Array.isArray(keyword) ? keyword : [keyword]),
+      );
+    })(target, key, descriptor);
+  };
+}

--- a/src/module.ts
+++ b/src/module.ts
@@ -6,5 +6,6 @@ export * from "./Placeholder";
 export * from "./Prerequisite";
 export * from "./RouteIcon";
 export * from "./SecretKey";
+export * from "./SelectBenchmark";
 export * from "./SelectorParam";
 export * from "./Standalone";


### PR DESCRIPTION
This pull request includes several updates and additions to the `@wrtnio/decorators` package, focusing on dependency updates and new functionality. The most important changes include updating dependencies in `package.json`, modifying the `RouteIcon` function, and adding a new `SelectBenchmark` function.

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R17): Updated versions of `@nestia/core`, `@nestia/fetcher`, `@nestia/sdk`, `@samchon/openapi`, and `typia`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R17) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L28-R28)

Function modifications and additions:

* [`src/RouteIcon.ts`](diffhunk://#diff-71066b69a5c406e5804b9474a5bd0cd27b636849e9188df0f1b3d118be03927eL8-R13): Modified the `RouteIcon` function to remove unnecessary `undefined` type from the `key` parameter and adjusted the decorator call to avoid using `key!`.
* [`src/SelectBenchmark.ts`](diffhunk://#diff-ef918e3fba90f6f488ca866ea1ba9ad8d76c4afb1753ed1d37cbfc45929908d8R1-R16): Added a new `SelectBenchmark` function that customizes Swagger properties for benchmark selection.
* [`src/module.ts`](diffhunk://#diff-030fc083b2cbf5cf008cfc0c49bb4f1b8d97ac07f93a291d068d81b4d1416f70R9): Exported the new `SelectBenchmark` function.